### PR TITLE
feat: SDK024 — streaming readStream without explicit schema

### DIFF
--- a/sparkdoctor/rules/sdk024_streaming_without_schema.py
+++ b/sparkdoctor/rules/sdk024_streaming_without_schema.py
@@ -1,0 +1,97 @@
+"""
+SDK024 — Streaming readStream without explicit schema.
+
+Severity: INFO
+"""
+from __future__ import annotations
+
+import ast
+
+from sparkdoctor.lint.base import Category, Diagnostic, Rule, Severity
+from sparkdoctor.rules._helpers import _has_pyspark_import
+
+
+class StreamingWithoutSchemaRule(Rule):
+    """Detects readStream chains that do not include a .schema() call."""
+
+    rule_id = "SDK024"
+    severity = Severity.INFO
+    title = "Streaming read without explicit schema"
+    category = Category.CORRECTNESS
+
+    _EXPLANATION = (
+        "Streaming jobs run indefinitely. A schema inferred at startup will break "
+        "when the source schema changes, causing the stream to fail silently or "
+        "corrupt data. Explicit schemas also prevent Spark from doing a schema "
+        "inference scan at startup which adds latency."
+    )
+
+    _SUGGESTION = (
+        "Define an explicit schema for streaming reads.\n"
+        "  # Bad:  spark.readStream.format(\"json\").load(path)\n"
+        "  # Good: spark.readStream.schema(my_schema).format(\"json\").load(path)"
+    )
+
+    def check(self, tree: ast.AST, source_lines: list[str]) -> list[Diagnostic]:
+        if not _has_pyspark_import(tree):
+            return []
+
+        diagnostics: list[Diagnostic] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            # Look for .load() or .table() at the end of a readStream chain
+            if node.func.attr not in ("load", "table", "start"):
+                continue
+            if not self._chain_has_read_stream(node):
+                continue
+            if self._chain_has_schema(node):
+                continue
+
+            diagnostics.append(
+                Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=self.severity,
+                    message="readStream without explicit .schema() — "
+                    "inferred schema will break on source changes",
+                    explanation=self._EXPLANATION,
+                    suggestion=self._SUGGESTION,
+                    line=node.lineno,
+                    col=node.col_offset,
+                )
+            )
+        return diagnostics
+
+    def _chain_has_read_stream(self, node: ast.AST) -> bool:
+        """Walk the receiver chain to check if readStream is present."""
+        current = node
+        while True:
+            if isinstance(current, ast.Call):
+                if isinstance(current.func, ast.Attribute):
+                    current = current.func.value
+                else:
+                    return False
+            elif isinstance(current, ast.Attribute):
+                if current.attr == "readStream":
+                    return True
+                current = current.value
+            else:
+                return False
+
+    def _chain_has_schema(self, node: ast.AST) -> bool:
+        """Walk the receiver chain to check if .schema() is called."""
+        current = node
+        while True:
+            if isinstance(current, ast.Call):
+                if isinstance(current.func, ast.Attribute):
+                    if current.func.attr == "schema":
+                        return True
+                    current = current.func.value
+                else:
+                    return False
+            elif isinstance(current, ast.Attribute):
+                current = current.value
+            else:
+                return False

--- a/tests/rules/test_sdk024.py
+++ b/tests/rules/test_sdk024.py
@@ -1,0 +1,86 @@
+"""Tests for SDK024 — Streaming read without explicit schema."""
+import ast
+
+from sparkdoctor.rules.sdk024_streaming_without_schema import StreamingWithoutSchemaRule
+
+RULE = StreamingWithoutSchemaRule()
+
+_PYSPARK = "from pyspark.sql import SparkSession\n"
+
+
+def check(source: str):
+    tree = ast.parse(source)
+    return RULE.check(tree, source.splitlines())
+
+
+# ── True positive ───────────────────────────────────────────────────────────
+
+
+def test_readstream_without_schema():
+    source = _PYSPARK + (
+        'df = spark.readStream.format("json").load("s3://bucket/incoming/")\n'
+    )
+    results = check(source)
+    assert len(results) == 1
+    assert results[0].rule_id == "SDK024"
+
+
+def test_kafka_readstream_without_schema():
+    source = _PYSPARK + (
+        'df = (spark.readStream\n'
+        '    .format("kafka")\n'
+        '    .option("kafka.bootstrap.servers", "broker:9092")\n'
+        '    .option("subscribe", "events")\n'
+        '    .load())\n'
+    )
+    results = check(source)
+    assert len(results) == 1
+
+
+# ── True negative ───────────────────────────────────────────────────────────
+
+
+def test_readstream_with_schema():
+    source = _PYSPARK + (
+        'df = spark.readStream.schema(my_schema).format("json").load(path)\n'
+    )
+    results = check(source)
+    assert results == []
+
+
+def test_batch_read_without_schema():
+    """Batch reads are not streaming — should not trigger."""
+    source = _PYSPARK + (
+        'df = spark.read.format("json").load("s3://bucket/data/")\n'
+    )
+    results = check(source)
+    assert results == []
+
+
+def test_no_pyspark_import():
+    source = 'df = spark.readStream.format("json").load("path")\n'
+    results = check(source)
+    assert results == []
+
+
+# ── Edge case ───────────────────────────────────────────────────────────────
+
+
+def test_readstream_with_schema_in_middle():
+    source = _PYSPARK + (
+        'df = (spark.readStream\n'
+        '    .schema(event_schema)\n'
+        '    .format("json")\n'
+        '    .option("maxFilesPerTrigger", 100)\n'
+        '    .load("s3://bucket/incoming/"))\n'
+    )
+    results = check(source)
+    assert results == []
+
+
+def test_readstream_table_without_schema():
+    source = _PYSPARK + (
+        'df = spark.readStream.table("my_catalog.events")\n'
+    )
+    results = check(source)
+    assert len(results) == 1


### PR DESCRIPTION
Closes #2

## Summary
- Adds SDK024 rule: detects `readStream` chains without `.schema()` call
- Streaming jobs with inferred schemas break silently when source schema changes
- INFO severity — flags the risk without blocking

## Detection
Walks the method chain from `.load()`/`.table()`/`.start()` backward, checks for `readStream` presence and absence of `.schema()` call.

## Tests (7)
- True positives: JSON readStream without schema, Kafka readStream without schema
- True negatives: readStream with schema, batch read, no pyspark import
- Edge cases: schema in middle of chain, `.table()` without schema

## Test plan
- [x] `pytest tests/rules/test_sdk024.py -v` — 7/7 pass
- [x] Full suite: 214 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added analysis rule to detect PySpark streaming reads lacking explicit schema definitions, improving data pipeline quality checks.

* **Tests**
  * Added comprehensive test coverage for the new streaming schema validation rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->