### PR TITLE
feat: SDK008 — detect cross-DataFrame column reference

### DIFF
--- a/sparkdoctor/rules/sdk008_cross_df_column_ref.py
+++ b/sparkdoctor/rules/sdk008_cross_df_column_ref.py
@@ -54,7 +54,10 @@ class CrossDataFrameColumnRefRule(Rule):
             if node.func.attr not in self._TARGET_METHODS:
                 continue
 
-            # Get the receiver DF name
+            # Get the receiver DF name — only handles simple Name receivers.
+            # Chained calls like df2.filter(...).select(df1.col) are skipped
+            # because the receiver is a Call node, not a Name. This is
+            # conservative to avoid false positives.
             receiver = node.func.value
             if not isinstance(receiver, ast.Name):
                 continue
@@ -82,7 +85,13 @@ class CrossDataFrameColumnRefRule(Rule):
         return diagnostics
 
     def _find_df_variables(self, tree: ast.AST) -> set[str]:
-        """Find variable names likely holding DataFrames."""
+        """Find variable names likely holding DataFrames.
+
+        Detects assignments of the form ``var = obj.method(...)``, which covers
+        patterns like ``spark.read.parquet()`` and ``df.filter()``.  Does not
+        detect plain function calls (``df = load()``), tuple unpacking, or
+        function parameters — intentionally conservative to reduce false positives.
+        """
         df_vars: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Assign):

--- a/tests/rules/test_sdk008.py
+++ b/tests/rules/test_sdk008.py
@@ -1,6 +1,8 @@
 """Tests for SDK008 — Cross-DataFrame column reference."""
 import ast
 
+import pytest
+
 from sparkdoctor.rules.sdk008_cross_df_column_ref import CrossDataFrameColumnRefRule
 
 RULE = CrossDataFrameColumnRefRule()
@@ -91,3 +93,20 @@ def test_cross_df_in_withcolumn():
     )
     results = check(source)
     assert len(results) == 1
+
+
+@pytest.mark.parametrize("method,call", [
+    ("where", "df2.where(df1.active)"),
+    ("drop", "df2.drop(df1.col)"),
+    ("groupBy", "df2.groupBy(df1.category)"),
+    ("orderBy", "df2.orderBy(df1.timestamp)"),
+])
+def test_cross_df_in_other_methods(method, call):
+    source = _PYSPARK + (
+        "df1 = spark.read.parquet('a')\n"
+        "df2 = spark.read.parquet('b')\n"
+        f"result = {call}\n"
+    )
+    results = check(source)
+    assert len(results) == 1
+    assert results[0].rule_id == "SDK008"


### PR DESCRIPTION
## Summary
- Adds SDK008 rule that detects `df1.colA` used inside `df2.select()` / `df2.filter()` etc.
- WARNING severity, correctness category
- 7 tests covering true positives, true negatives, and edge cases

## Test plan
- [x] `pytest tests/rules/test_sdk008.py` — 7 tests pass
- [x] `ruff check` clean

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SDK008 lint rule to detect cross-DataFrame column references in PySpark code. The rule identifies when columns from one DataFrame are incorrectly referenced within operations (such as select, filter, where, withColumn, drop, groupBy, orderBy) on another DataFrame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->