### PR TITLE
Add SDK018: inconsistent column reference style detection

### DIFF
--- a/sparkdoctor/rules/sdk018_inconsistent_column_ref.py
+++ b/sparkdoctor/rules/sdk018_inconsistent_column_ref.py
@@ -33,36 +33,75 @@ class InconsistentColumnRefRule(Rule):
         '  df.select("name", "age")                 # consistent string'
     )
 
+    # DataFrame methods — used to identify DF variables and attribute access context.
     _DF_METHODS = {
         "select", "filter", "where", "withColumn", "groupBy",
-        "orderBy", "sort", "agg", "drop", "join",
+        "orderBy", "sort", "agg", "drop", "join", "union", "unionAll",
+        "crossJoin", "limit", "distinct", "dropDuplicates",
+        "withColumnRenamed", "alias", "toDF",
     }
+
+    # Attributes that are NOT column access on a DataFrame.
+    _NON_COLUMN_ATTRS = {
+        "columns", "schema", "dtypes", "rdd", "write", "writeStream",
+        "read", "readStream", "sql", "conf", "sparkContext", "udf",
+        "cache", "persist", "unpersist", "count", "collect",
+        "show", "head", "first", "take", "toPandas",
+        "alias", "asc", "desc", "cast",
+        "otherwise", "over", "between", "isin",
+        "isNull", "isNotNull", "na", "stat",
+        "explain", "printSchema", "describe", "summary",
+        "createOrReplaceTempView", "createTempView",
+    } | _DF_METHODS
 
     def check(self, tree: ast.AST, source_lines: list[str]) -> list[Diagnostic]:
         if not _has_pyspark_import(tree):
             return []
 
+        # Step 1: Resolve functions module aliases from imports.
+        func_aliases = self._find_functions_aliases(tree)
+        has_bare_col = self._has_bare_col_import(tree)
+
+        # Step 2: Find DataFrame variable names (assigned from DF method chains).
+        df_vars = self._find_df_variables(tree)
+
+        # Step 3: Scan entire file for column reference styles.
         styles: dict[str, list[int]] = {}
 
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            if not isinstance(node.func, ast.Attribute):
-                continue
-
-            if node.func.attr == "col":
-                receiver = node.func.value
-                if isinstance(receiver, ast.Name) and receiver.id in ("F", "functions"):
+            # F.col() / functions.col() / sf.col() / bare col()
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Attribute) and node.func.attr == "col":
+                    receiver = node.func.value
+                    if isinstance(receiver, ast.Name) and receiver.id in func_aliases:
+                        styles.setdefault("F.col()", []).append(node.lineno)
+                elif (
+                    has_bare_col
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "col"
+                ):
                     styles.setdefault("F.col()", []).append(node.lineno)
-                continue
 
-            if node.func.attr not in self._DF_METHODS:
-                continue
+            # df["col"] — only on known DataFrame variables
+            if (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in df_vars
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str)
+            ):
+                styles.setdefault('df["col"]', []).append(node.lineno)
 
-            for arg in node.args:
-                self._detect_styles_in_expr(arg, styles)
-            for kw in node.keywords:
-                self._detect_styles_in_expr(kw.value, styles)
+            # df.col — attribute access on known DataFrame variables
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in df_vars
+                and node.attr not in self._NON_COLUMN_ATTRS
+            ):
+                # Exclude if this attribute is itself a call target (df.select())
+                # We can't detect parent in ast.walk, so we rely on the exclusion set
+                styles.setdefault("df.col", []).append(node.lineno)
 
         if len(styles) < 2:
             return []
@@ -83,24 +122,86 @@ class InconsistentColumnRefRule(Rule):
             )
         ]
 
-    def _detect_styles_in_expr(self, node: ast.AST, styles: dict[str, list[int]]) -> None:
-        for child in ast.walk(node):
-            if isinstance(child, ast.Subscript):
-                if isinstance(child.slice, ast.Constant) and isinstance(
-                    child.slice.value, str
-                ):
-                    styles.setdefault('df["col"]', []).append(child.lineno)
-            elif (
-                isinstance(child, ast.Attribute)
-                and isinstance(child.value, ast.Name)
-                and child.attr not in self._DF_METHODS
-                and child.attr not in {
-                    "col", "columns", "schema", "dtypes", "rdd", "write",
-                    "read", "sql", "conf", "sparkContext", "udf",
-                    "cache", "persist", "unpersist", "count", "collect",
-                    "show", "head", "first", "take", "toPandas",
-                    "limit", "alias", "asc", "desc", "cast",
-                    "otherwise", "over", "between", "isin",
-                }
+    def _find_functions_aliases(self, tree: ast.AST) -> set[str]:
+        """Find all aliases for pyspark.sql.functions (e.g. F, sf, functions)."""
+        aliases: set[str] = set()
+        for node in ast.walk(tree):
+            # import pyspark.sql.functions as F
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "pyspark.sql.functions":
+                        aliases.add(alias.asname or "functions")
+            # from pyspark.sql import functions as F
+            elif isinstance(node, ast.ImportFrom) and node.module == "pyspark.sql":
+                for alias in node.names:
+                    if alias.name == "functions":
+                        aliases.add(alias.asname or "functions")
+        return aliases
+
+    def _has_bare_col_import(self, tree: ast.AST) -> bool:
+        """Check if `col` is directly imported (from pyspark.sql.functions import col)."""
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and node.module in ("pyspark.sql.functions", "pyspark.sql")
             ):
-                styles.setdefault("df.col", []).append(child.lineno)
+                for alias in node.names:
+                    if alias.name == "col":
+                        return True
+        return False
+
+    def _find_df_variables(self, tree: ast.AST) -> set[str]:
+        """Find variable names that are likely DataFrames.
+
+        Tracks names assigned from:
+        - spark.read / spark.readStream chains
+        - DataFrame method calls (.filter(), .select(), etc.)
+        - spark.createDataFrame() / spark.table() / spark.sql()
+        """
+        df_vars: set[str] = set()
+        # Common conventional names
+        df_vars.add("df")
+
+        spark_creators = {"read", "readStream", "createDataFrame", "table", "sql", "range"}
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not isinstance(node.value, ast.Call):
+                continue
+
+            # Check if RHS is a DF method chain
+            call = node.value
+            if isinstance(call.func, ast.Attribute):
+                method = call.func.attr
+                if method in self._DF_METHODS or method in spark_creators:
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            df_vars.add(target.id)
+                    continue
+
+                # Check receiver chain for DF methods (e.g. spark.read.csv())
+                if self._chain_has_df_method(call):
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            df_vars.add(target.id)
+
+        return df_vars
+
+    def _chain_has_df_method(self, node: ast.AST) -> bool:
+        """Check if a call chain contains any DataFrame method."""
+        current = node
+        spark_creators = {"read", "readStream", "createDataFrame", "table", "sql", "range"}
+        all_methods = self._DF_METHODS | spark_creators
+        while True:
+            if isinstance(current, ast.Call) and isinstance(current.func, ast.Attribute):
+                if current.func.attr in all_methods:
+                    return True
+                current = current.func.value
+            elif isinstance(current, ast.Attribute):
+                if current.attr in all_methods:
+                    return True
+                current = current.value
+            else:
+                return False

--- a/tests/corpus/column_ref_style.py
+++ b/tests/corpus/column_ref_style.py
@@ -10,3 +10,7 @@ mixed = df.select(F.col("name"), df["age"])  # expect: SDK018
 
 # Consistent F.col — should not trigger
 consistent = df.select(F.col("name"), F.col("age"))  # expect: none
+
+# config subscript should not count as df["col"]
+config = {"key": "value"}
+x = config["key"]  # expect: none

--- a/tests/rules/test_sdk018.py
+++ b/tests/rules/test_sdk018.py
@@ -13,8 +13,12 @@ def check(source: str):
     return RULE.check(tree, source.splitlines())
 
 
+# ── True positive ───────────────────────────────────────────────────────────
+
+
 def test_mixed_fcol_and_subscript():
     source = _PYSPARK + (
+        "df = spark.read.parquet('/data')\n"
         'df.select(F.col("name"), df["age"])\n'
     )
     results = check(source)
@@ -26,12 +30,53 @@ def test_mixed_fcol_and_subscript():
 
 def test_mixed_fcol_and_dot():
     source = _PYSPARK + (
+        "df = spark.read.parquet('/data')\n"
         'x = F.col("name")\n'
-        'df.select(F.col("name"), df.custom_field)\n'
+        "df.select(F.col(\"name\"), df.custom_field)\n"
     )
     results = check(source)
     assert len(results) == 1
     assert "F.col()" in results[0].message
+
+
+def test_file_wide_subscript_outside_method():
+    """df["col"] outside a DF method call should still be detected."""
+    source = _PYSPARK + (
+        "df = spark.read.parquet('/data')\n"
+        'age = df["age"]\n'
+        'name = F.col("name")\n'
+    )
+    results = check(source)
+    assert len(results) == 1
+    assert 'df["col"]' in results[0].message
+    assert "F.col()" in results[0].message
+
+
+def test_sf_alias_detected():
+    """import pyspark.sql.functions as sf should be detected."""
+    source = (
+        "from pyspark.sql import SparkSession\n"
+        "import pyspark.sql.functions as sf\n"
+        "df = spark.read.parquet('/data')\n"
+        'df.select(sf.col("name"), df["age"])\n'
+    )
+    results = check(source)
+    assert len(results) == 1
+
+
+def test_bare_col_import():
+    """from pyspark.sql.functions import col should be detected."""
+    source = (
+        "from pyspark.sql import SparkSession\n"
+        "from pyspark.sql.functions import col\n"
+        "df = spark.read.parquet('/data')\n"
+        'df.select(col("name"), df["age"])\n'
+    )
+    results = check(source)
+    assert len(results) == 1
+
+
+# ── True negative ───────────────────────────────────────────────────────────
 
 
 def test_consistent_fcol():
@@ -58,7 +103,29 @@ def test_no_pyspark_import():
 
 def test_single_style_no_diagnostic():
     source = _PYSPARK + (
+        "df = spark.read.parquet('/data')\n"
         'df.select(df["name"], df["age"], df["city"])\n'
+    )
+    results = check(source)
+    assert results == []
+
+
+def test_config_subscript_not_flagged():
+    """config["key"] should NOT be detected as df["col"] style."""
+    source = _PYSPARK + (
+        'config = {"key": "value"}\n'
+        'df.select(F.col("name"))\n'
+        'x = config["key"]\n'
+    )
+    results = check(source)
+    assert results == []
+
+
+def test_f_sum_not_flagged_as_df_col():
+    """F.sum() should NOT be detected as df.col style."""
+    source = _PYSPARK + (
+        "df = spark.read.parquet('/data')\n"
+        'df.select(F.col("name"), F.sum("amount"))\n'
     )
     results = check(source)
     assert results == []


### PR DESCRIPTION
Closes #16

- Adds SDK018 rule to detect mixed column reference styles
- Unit tests and corpus coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SDK009 rule: Detects excessively long transformation chains in PySpark code.
  * Added SDK018 rule: Detects inconsistent column reference styles in PySpark code.

* **Tests**
  * Added comprehensive test coverage for both new linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->